### PR TITLE
Update JCommander to latest version

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>com.beust</groupId>
       <artifactId>jcommander</artifactId>
-      <version>1.75</version>
+      <version>1.78</version>
     </dependency>
     <dependency>
       <groupId>com.github.bzacar</groupId>


### PR DESCRIPTION
Updating JCommander to 1.78 to keep Java8 compatibility
https://github.com/cbeust/jcommander/issues/473